### PR TITLE
Support disabling Shorts results in CLI search

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ uvicorn app.main:app --reload
 
 ## Запуск CLI
 ```
-python -m app.cli search --topic "айфон лайфхаки" --n 5 --region RU --after "2025-08-01T00:00:00Z" --shorts true
+python -m app.cli search --topic "айфон лайфхаки" --n 5 --region RU --after "2025-08-01T00:00:00Z" --no-shorts
 python -m app.cli analyze --video-id YyyZzz123
 python -m app.cli scenario --video-id YyyZzz123 --topic "айфон лайфхаки"
 python -m app.cli storyboard --scenario path/to/scenario.json --target shorts

--- a/app/cli.py
+++ b/app/cli.py
@@ -41,7 +41,8 @@ def main():
     p_search.add_argument('--n', type=int, default=5)
     p_search.add_argument('--region', required=True)
     p_search.add_argument('--after', required=True)
-    p_search.add_argument('--shorts', type=bool, default=True)
+    p_search.add_argument('--shorts', action='store_true', default=True)
+    p_search.add_argument('--no-shorts', dest='shorts', action='store_false')
     p_search.set_defaults(func=cmd_search)
 
     p_an = sub.add_parser('analyze')


### PR DESCRIPTION
## Summary
- Switch to boolean flags `--shorts`/`--no-shorts` for search command
- Document `--no-shorts` usage in CLI examples

## Testing
- `CI=true pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68c83746d788832ea6a49381de3973e1