### PR TITLE
Add key object extraction from video analysis

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -12,14 +12,27 @@ def cmd_search(args):
 def cmd_analyze(args):
     with media_probe.pull_transient(args.video_id) as (audio_path, video_path):
         transcript = stt.transcribe(audio_path)
-        shots = vision_shots.detect_shots(video_path) if video_path else []
-    print(json.dumps({"transcript": transcript.model_dump(), "shots": [s.model_dump() for s in shots]}, ensure_ascii=False, indent=2))
+        if video_path:
+            shots, key_objects = vision_shots.detect_shots(video_path)
+        else:
+            shots, key_objects = [], []
+    print(
+        json.dumps(
+            {
+                "transcript": transcript.model_dump(),
+                "shots": [s.model_dump() for s in shots],
+                "key_objects": [ko.model_dump() for ko in key_objects],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
 
 
 def cmd_scenario(args):
     with media_probe.pull_transient(args.video_id) as (audio_path, video_path):
         transcript = stt.transcribe(audio_path)
-        shots = vision_shots.detect_shots(video_path) if video_path else []
+        shots, _ = vision_shots.detect_shots(video_path) if video_path else ([], [])
     scn = llm_scenario.make_ru_scenario(transcript, shots, args.topic)
     print(scn.model_dump_json(indent=2, ensure_ascii=False))
 

--- a/app/main.py
+++ b/app/main.py
@@ -34,10 +34,10 @@ def analyze(payload: dict) -> AnalysisResult:
             raise HTTPException(500, "Audio not extracted")
         transcript = stt.transcribe(audio_path)
         if video_path:
-            shots = vision_shots.detect_shots(video_path)
+            shots, key_objects = vision_shots.detect_shots(video_path)
         else:
-            shots = []
-    return AnalysisResult(transcript=transcript, shots=shots)
+            shots, key_objects = [], []
+    return AnalysisResult(transcript=transcript, shots=shots, key_objects=key_objects)
 
 
 @app.post("/scenario", response_model=Scenario)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -29,9 +29,18 @@ class Shot(BaseModel):
     end_sec: float = Field(ge=0)
 
 
+class KeyObject(BaseModel):
+    description: str
+    start_sec: float = Field(ge=0)
+    end_sec: float = Field(ge=0)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    categories: List[str] = Field(default_factory=list)
+
+
 class AnalysisResult(BaseModel):
     transcript: Transcript
     shots: List[Shot]
+    key_objects: List[KeyObject] = Field(default_factory=list)
 
 
 class VoiceLine(BaseModel):

--- a/app/vision_shots.py
+++ b/app/vision_shots.py
@@ -1,5 +1,15 @@
 from google.cloud import videointelligence
-from .schemas import Shot
+from .schemas import Shot, KeyObject
+
+
+def _duration_to_seconds(duration) -> float:
+    if not duration:
+        return 0.0
+    if hasattr(duration, "total_seconds"):
+        return float(duration.total_seconds())
+    seconds = float(getattr(duration, "seconds", 0.0))
+    nanos = float(getattr(duration, "nanos", 0.0))
+    return seconds + nanos / 1_000_000_000.0
 
 
 def detect_shots(file_path: str):
@@ -7,13 +17,67 @@ def detect_shots(file_path: str):
     with open(file_path, "rb") as f:
         input_content = f.read()
     operation = client.annotate_video(
-        request={"features": [videointelligence.Feature.SHOT_CHANGE_DETECTION], "input_content": input_content}
+        request={
+            "features": [
+                videointelligence.Feature.SHOT_CHANGE_DETECTION,
+                videointelligence.Feature.LABEL_DETECTION,
+            ],
+            "input_content": input_content,
+        }
     )
     result = operation.result(timeout=180)
-    annotation = result.annotation_results[0]
+    annotation_results = getattr(result, "annotation_results", [])
+    if not annotation_results:
+        return [], []
+    annotation = annotation_results[0]
     shots = []
-    for shot in annotation.shot_annotations:
-        start = shot.start_time_offset.total_seconds()
-        end = shot.end_time_offset.total_seconds()
+    for shot in getattr(annotation, "shot_annotations", []):
+        start = _duration_to_seconds(getattr(shot, "start_time_offset", None))
+        end = _duration_to_seconds(getattr(shot, "end_time_offset", None))
         shots.append(Shot(start_sec=start, end_sec=end))
-    return shots
+    key_objects: list[KeyObject] = []
+
+    def _collect_categories(entities) -> list[str]:
+        return [
+            entity.description
+            for entity in entities or []
+            if getattr(entity, "description", None)
+        ]
+
+    def _append_key_object(description: str, categories, segment, confidence):
+        start = _duration_to_seconds(getattr(segment, "start_time_offset", None)) if segment else 0.0
+        end = _duration_to_seconds(getattr(segment, "end_time_offset", None)) if segment else 0.0
+        key_objects.append(
+            KeyObject(
+                description=description or "",
+                categories=list(categories or []),
+                start_sec=start,
+                end_sec=end,
+                confidence=confidence,
+            )
+        )
+
+    for label in getattr(annotation, "shot_label_annotations", []):
+        description = getattr(getattr(label, "entity", None), "description", "")
+        categories = _collect_categories(getattr(label, "category_entities", []))
+        for segment_info in getattr(label, "segments", []):
+            segment = getattr(segment_info, "segment", None)
+            confidence = getattr(segment_info, "confidence", None)
+            _append_key_object(description, categories, segment, confidence)
+
+    for label in getattr(annotation, "segment_label_annotations", []):
+        description = getattr(getattr(label, "entity", None), "description", "")
+        categories = _collect_categories(getattr(label, "category_entities", []))
+        for segment_info in getattr(label, "segments", []):
+            segment = getattr(segment_info, "segment", None)
+            confidence = getattr(segment_info, "confidence", None)
+            _append_key_object(description, categories, segment, confidence)
+
+    for obj in getattr(annotation, "object_annotations", []):
+        description = getattr(getattr(obj, "entity", None), "description", "")
+        categories = _collect_categories(getattr(obj, "category_entities", []))
+        segment = getattr(obj, "segment", None)
+        confidence = getattr(obj, "confidence", None)
+        _append_key_object(description, categories, segment, confidence)
+
+    return shots, key_objects

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -9,6 +9,7 @@ from app.schemas import (
     StoryScene,
     Transcript,
     Shot,
+    KeyObject,
     AnalysisResult,
 )
 
@@ -44,6 +45,8 @@ def test_analysis_result_model():
     res = AnalysisResult(
         transcript=Transcript(segments=[]),
         shots=[Shot(start_sec=0.0, end_sec=1.0)],
+        key_objects=[KeyObject(description="Car", start_sec=0.0, end_sec=1.0, confidence=0.9, categories=["Vehicle"])],
     )
     assert res.transcript.segments == []
     assert res.shots[0].start_sec == 0.0
+    assert res.key_objects[0].categories == ["Vehicle"]

--- a/tests/test_vision_shots.py
+++ b/tests/test_vision_shots.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from google.cloud import videointelligence
+
+from app.vision_shots import detect_shots
+
+
+class DurationStub:
+    def __init__(self, seconds: float = 0.0, nanos: float = 0.0):
+        self.seconds = seconds
+        self.nanos = nanos
+
+    def total_seconds(self) -> float:
+        return float(self.seconds) + float(self.nanos) / 1_000_000_000.0
+
+
+def _make_operation(result):
+    operation = MagicMock()
+    operation.result.return_value = result
+    return operation
+
+
+@patch("app.vision_shots.videointelligence.VideoIntelligenceServiceClient")
+def test_detect_shots_parses_key_objects(mock_client_cls, tmp_path):
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"video")
+
+    shot_annotation = SimpleNamespace(
+        start_time_offset=DurationStub(0),
+        end_time_offset=DurationStub(5),
+    )
+    label_segment = SimpleNamespace(
+        segment=SimpleNamespace(
+            start_time_offset=DurationStub(1),
+            end_time_offset=DurationStub(4, 500_000_000),
+        ),
+        confidence=0.95,
+    )
+    label_annotation = SimpleNamespace(
+        entity=SimpleNamespace(description="Car"),
+        category_entities=[SimpleNamespace(description="Vehicle")],
+        segments=[label_segment],
+    )
+    annotation_result = SimpleNamespace(
+        shot_annotations=[shot_annotation],
+        shot_label_annotations=[label_annotation],
+        segment_label_annotations=[],
+        object_annotations=[],
+    )
+    mock_result = SimpleNamespace(annotation_results=[annotation_result])
+
+    mock_client = MagicMock()
+    mock_client.annotate_video.return_value = _make_operation(mock_result)
+    mock_client_cls.return_value = mock_client
+
+    shots, key_objects = detect_shots(str(video_path))
+
+    assert len(shots) == 1
+    assert shots[0].start_sec == pytest.approx(0.0)
+    assert shots[0].end_sec == pytest.approx(5.0)
+    assert len(key_objects) == 1
+    assert key_objects[0].description == "Car"
+    assert key_objects[0].categories == ["Vehicle"]
+    assert key_objects[0].confidence == pytest.approx(0.95)
+    assert key_objects[0].start_sec == pytest.approx(1.0)
+    assert key_objects[0].end_sec == pytest.approx(4.5)
+
+    features = mock_client.annotate_video.call_args.kwargs["request"]["features"]
+    assert videointelligence.Feature.LABEL_DETECTION in features
+    assert videointelligence.Feature.SHOT_CHANGE_DETECTION in features
+
+
+@patch("app.vision_shots.videointelligence.VideoIntelligenceServiceClient")
+def test_detect_shots_handles_empty_annotations(mock_client_cls, tmp_path):
+    video_path = tmp_path / "sample.mp4"
+    video_path.write_bytes(b"video")
+
+    mock_client = MagicMock()
+    mock_client.annotate_video.return_value = _make_operation(SimpleNamespace(annotation_results=[]))
+    mock_client_cls.return_value = mock_client
+
+    shots, key_objects = detect_shots(str(video_path))
+
+    assert shots == []
+    assert key_objects == []


### PR DESCRIPTION
## Summary
- request label annotations alongside shot detection in the GCV pipeline and expose parsed key objects
- extend the AnalysisResult schema plus CLI/API outputs with structured key object details
- add unit coverage for the shot/key-object parsing logic with mocked Video Intelligence responses

## Testing
- `pytest` *(fails: missing third-party dependencies because packages cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c849de6d94832e9342d6e6399ed826