### PR TITLE
Add retry logic and logging for YouTube client requests

### DIFF
--- a/app/youtube_client.py
+++ b/app/youtube_client.py
@@ -1,18 +1,82 @@
-import httpx
+import logging
+import os
+import time
 from typing import Any, Dict, List
+
+import httpx
+
 from .settings import settings
 from .schemas import Candidate
 
 BASE_URL = "https://www.googleapis.com/youtube/v3"
 
 
+class YouTubeAPIRequestError(RuntimeError):
+    """Raised when the YouTube API repeatedly fails."""
+
+
+_LOG_LEVEL_NAME = os.getenv("YOUTUBE_CLIENT_LOG_LEVEL", "INFO").upper()
+_ENV_LOG_LEVEL = getattr(logging, _LOG_LEVEL_NAME, None)
+_INVALID_LOG_LEVEL = not isinstance(_ENV_LOG_LEVEL, int)
+_LOG_LEVEL = _ENV_LOG_LEVEL if not _INVALID_LOG_LEVEL else logging.INFO
+
+if not logging.getLogger().hasHandlers():
+    logging.basicConfig(level=_LOG_LEVEL)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(_LOG_LEVEL)
+
+if _INVALID_LOG_LEVEL:
+    logger.warning(
+        "Invalid log level '%s' provided for YOUTUBE_CLIENT_LOG_LEVEL. Defaulting to INFO.",
+        _LOG_LEVEL_NAME,
+    )
+
+
 def _request(path: str, params: Dict[str, Any]) -> Dict[str, Any]:
     params = dict(params)
     params["key"] = settings.YOUTUBE_API_KEY
+    sanitized_params = {k: v for k, v in params.items() if k != "key"}
+
+    max_attempts = 3
+    backoff_seconds = 1.0
+    last_exception: Exception | None = None
+
     with httpx.Client(timeout=30) as client:
-        resp = client.get(f"{BASE_URL}{path}", params=params)
-        resp.raise_for_status()
-        return resp.json()
+        for attempt in range(1, max_attempts + 1):
+            logger.info(
+                "Requesting %s with params %s (attempt %s/%s)",
+                path,
+                sanitized_params,
+                attempt,
+                max_attempts,
+            )
+            try:
+                resp = client.get(f"{BASE_URL}{path}", params=params)
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPError as exc:
+                last_exception = exc
+                logger.warning(
+                    "Request to %s failed on attempt %s/%s: %s",
+                    path,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                if attempt < max_attempts:
+                    time.sleep(backoff_seconds)
+                    backoff_seconds *= 2
+
+    logger.error(
+        "Request to %s exhausted %s attempts with params %s.",
+        path,
+        max_attempts,
+        sanitized_params,
+    )
+    raise YouTubeAPIRequestError(
+        f"Failed to call YouTube API endpoint '{path}' after {max_attempts} attempts."
+    ) from last_exception
 
 
 def search_list(**params) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- integrate configurable logging into the YouTube client with a custom exception
- implement manual exponential backoff with three retry attempts for API requests
- raise a meaningful error when YouTube API calls exhaust retries

## Testing
- pytest *(fails: missing dependencies such as httpx, pydantic, google)*

------
https://chatgpt.com/codex/tasks/task_e_68c84b71e188832e9f3ce5a00ff0121c