### PR TITLE
Handle transcription segments attribute response

### DIFF
--- a/app/stt.py
+++ b/app/stt.py
@@ -1,6 +1,12 @@
+from typing import Any
+
 from openai import OpenAI
+
+from .schemas import Segment, Transcript
 from .settings import settings
-from .schemas import Transcript, Segment
+
+
+_SENTINEL = object()
 
 client = OpenAI(api_key=settings.OPENAI_API_KEY)
 
@@ -12,5 +18,38 @@ def transcribe(audio_path: str) -> Transcript:
             file=f,
             response_format="verbose_json",
         )
-    segments = [Segment(text=s["text"], start=s["start"], end=s["end"]) for s in resp["segments"]]
+    segments_payload = _extract_segments(resp)
+    segments = [_segment_from_payload(segment) for segment in segments_payload]
     return Transcript(segments=segments)
+
+
+def _extract_segments(resp: Any):
+    segments = getattr(resp, "segments", _SENTINEL)
+    if segments is _SENTINEL or segments is None:
+        payload = _dump_model(resp)
+        if payload is not None:
+            segments = payload.get("segments", _SENTINEL)
+    if segments is _SENTINEL or segments is None:
+        raise ValueError("Transcription response did not include segments.")
+    return segments
+
+
+def _segment_from_payload(segment: Any) -> Segment:
+    payload = _dump_model(segment)
+    if payload is None:
+        payload = {
+            "text": getattr(segment, "text"),
+            "start": getattr(segment, "start"),
+            "end": getattr(segment, "end"),
+        }
+    return Segment(**payload)
+
+
+def _dump_model(obj: Any) -> dict[str, Any] | None:
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    if hasattr(obj, "dict"):
+        return obj.dict()
+    return None

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app import stt
+
+
+class _DummyClient:
+    def __init__(self, response):
+        self._response = response
+        self.audio = SimpleNamespace(transcriptions=self)
+
+    def create(self, *args, **kwargs):
+        return self._response
+
+
+def _patch_client(monkeypatch, response):
+    monkeypatch.setattr(stt, "client", _DummyClient(response))
+
+
+def _write_audio(tmp_path):
+    audio_path = tmp_path / "audio.mp3"
+    audio_path.write_bytes(b"fake-audio")
+    return audio_path
+
+
+def test_transcribe_with_segment_objects(monkeypatch, tmp_path):
+    segments = [
+        SimpleNamespace(text="hello", start=0.0, end=1.0),
+        SimpleNamespace(text="world", start=1.0, end=2.0),
+    ]
+    response = SimpleNamespace(segments=segments)
+    _patch_client(monkeypatch, response)
+
+    transcript = stt.transcribe(str(_write_audio(tmp_path)))
+
+    assert [s.text for s in transcript.segments] == ["hello", "world"]
+    assert [s.start for s in transcript.segments] == [0.0, 1.0]
+    assert [s.end for s in transcript.segments] == [1.0, 2.0]
+
+
+def test_transcribe_with_dict_response(monkeypatch, tmp_path):
+    payload = {
+        "segments": [
+            {"text": "line", "start": 0.0, "end": 3.5},
+        ]
+    }
+
+    class Response:
+        def dict(self):
+            return payload
+
+    _patch_client(monkeypatch, Response())
+
+    transcript = stt.transcribe(str(_write_audio(tmp_path)))
+
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0].text == "line"
+    assert transcript.segments[0].start == 0.0
+    assert transcript.segments[0].end == 3.5
+
+
+def test_transcribe_without_segments(monkeypatch, tmp_path):
+    class Response:
+        def dict(self):
+            return {}
+
+    _patch_client(monkeypatch, Response())
+
+    with pytest.raises(ValueError, match="did not include segments"):
+        stt.transcribe(str(_write_audio(tmp_path)))


### PR DESCRIPTION
## Summary
- update the STT transcription helper to read segment data from the new attribute-based OpenAI response shape and fall back to dumped payloads when available
- raise a clear error when the transcription response does not expose any segments
- add tests that cover segment objects, dictionary payloads, and missing segment scenarios

## Testing
- pytest *(fails: missing third-party dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84d0d61f0832ea8a680286b196b91